### PR TITLE
Metadata updates

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -39,3 +39,12 @@ attribute "salt/minion/master",
 	:recipes => [
 	'salt::minion'
 	]	
+
+attribute "salt/minion/grains",
+	:display_name => "Salt Grains",
+	:description =>
+	"Map of custom grains for tagging the minion. Each entry may contain a single string value or a list of strings.",
+	:required => "optional",
+	:recipes => [
+	'salt::minion'
+	]		


### PR DESCRIPTION
Updated the metadata to follow the <cookbook>::<recipe> standard naming conventions for recipes and to define a couple of the attributes in the metadata file.

These changes follow Chef conventions and also allow the cookbook to be used as-is in RightScale.
