### PR TITLE
Bump apt and fix 'bootstrap' issues

### DIFF
--- a/attributes/minion.rb
+++ b/attributes/minion.rb
@@ -25,3 +25,5 @@ else
 end
 
 default['salt']['minion']['grains'] = {}
+
+default['salt']['minion']['master_attribute'] = 'ipaddress'

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@ supports 'debian', '~> 7.0'
   supports os, '>= 5.0'
 end
 
-depends 'apt',              '~> 2.3.10'
+depends 'apt',              '~> 2.7.0'
 depends 'yum',              '~> 3.0'
 depends 'yum-epel'
 depends 'ohai'

--- a/recipes/minion.rb
+++ b/recipes/minion.rb
@@ -2,9 +2,9 @@
 # Cookbook Name:: chef-salt
 # Recipe:: default
 #
-# Copyright (C) 2014 
+# Copyright (C) 2014
 #
-# 
+#
 #
 
 # TODO: call sync grains command in Salt periodically to ensure the autmatic
@@ -18,14 +18,14 @@ package node.salt['minion']['package'] do
   action :install
 end
 
-service 'salt-minion' do 
+service 'salt-minion' do
   action :enable
 end
 
 unless node.salt['minion']['master']
   master_search = "role:#{node.salt['role']['master']}"
   if node.salt['minion']['master_environment'] and node.salt['minion']['master_environment'] != '_default'
-    master_search += " AND chef_environment:#{node.salt['minion']['master_environment']}" 
+    master_search += " AND chef_environment:#{node.salt['minion']['master_environment']}"
   end
 
   master_nodes = search(:node, master_search)

--- a/recipes/minion.rb
+++ b/recipes/minion.rb
@@ -31,7 +31,7 @@ unless node.salt['minion']['master']
   master_nodes = search(:node, master_search)
 
   # TODO: Find best IP address
-  master = master_nodes.collect { |n| n['ipaddress'] }
+  master = master_nodes.collect { |n| n[node['salt']['minion']['master_attribute']] }
 else
   master = [node.salt['minion']['master']]
 end


### PR DESCRIPTION
We ran into two issues when using this cookbook. One was we have a more modern version of apt in our repos, hence bumping the requirements. The second is bootstrapping this cookbook onto the first salt master, when this is in our base cookbook. Rather than creating complex logic in our base cookbook to include or not this recipe, we opted to make things fall through when there are no salt masters yet. The reason why is that we need the chef client run to complete, always. This change allows us to include the recipe on all chef nodes, regardless whether there is a salt master present. Once the salt master comes online, running chef-client manually on each node will reconfigure salt-minion to point to the master and do all the things it should do correctly.
