### PR TITLE
Switch RHEL repo from epel to saltstack oficial

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ platforms:
 - name: ubuntu-16.04
 - name: centos-5.11
 - name: centos-6.8
-- name: centos-7.1
+- name: centos-7.2
 - name: fedora-21
 - name: fedora-22
 - name: fedora-23
@@ -36,6 +36,24 @@ suites:
                 - larry
                 - curly
                 - moe
+  - name: version-pin
+    run_list:
+      - role[salt_master]
+      - role[salt_minion]
+    attributes:
+      salt:
+        minion:
+          master: 127.0.0.1
+          config:
+            grains:
+              quinoa: delicious
+              stooges:
+                - larry
+                - curly
+                - moe
+        version: 2016.3.0-1.el7
+    includes:
+      - centos-7.2
   - name: salt-api
     run_list:
       - role[salt_master]

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,3 @@
 source 'https://supermarket.chef.io'
 
 metadata
-
-group :integration do
-  cookbook 'minitest-handler', '~> 0.2'
-end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This file is used to list changes made in each version of the Salt Cookbook
 - **[PR #22](https://github.com/shortdudey123/chef-salt/pull/22)** - Update Ohai plugin to work with Ohai 4.x cookbook
 - **[PR #23](https://github.com/shortdudey123/chef-salt/pull/23)** - Update test-kitchen OS's
 - **[PR #24](https://github.com/shortdudey123/chef-salt/pull/24)** - update Berkshelf source
+- **[PR #25](https://github.com/shortdudey123/chef-salt/pull/25)** - Switch RHEL repo from epel to saltstack oficial
 
 ## 1.1.0
 * [Issue #4](https://github.com/darylrobbins/chef-salt/issues/4): Fixed master/minion search to use role instead of roles filter

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ This cooked has been confirmed to work on:
 ### Dependencies
 
 * apt
+* ohai
 * yum
-* yum-epel
 
 ## Attributes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,7 +19,6 @@ end
 
 depends 'apt'
 depends 'yum'
-depends 'yum-epel'
 depends 'ohai', '~> 4.0'
 
 attribute 'salt/version',

--- a/recipes/_setup.rb
+++ b/recipes/_setup.rb
@@ -43,5 +43,13 @@ when 'debian'
     end
   end
 when 'rhel'
-  include_recipe 'yum-epel' if node['platform_version'].to_i >= 5
+  minor_ver = node['salt']['version'] ? "archive/#{node['salt']['version'].split('-')[0]}" : 'latest'
+  gpg_keyname = node['platform_version'].to_i == 5 ? 'SALTSTACK-EL5-GPG-KEY' : 'SALTSTACK-GPG-KEY'
+
+  yum_repository 'saltstack-repo' do
+    description 'SaltStack repo for Red Hat Enterprise Linux $releasever'
+    baseurl "https://repo.saltstack.com/yum/redhat/$releasever/$basearch/#{minor_ver}"
+    gpgkey "https://repo.saltstack.com/yum/redhat/$releasever/$basearch/#{minor_ver}/#{gpg_keyname}.pub"
+    action :create
+  end
 end

--- a/test/integration/salt-api/serverspec/salt_spec.rb
+++ b/test/integration/salt-api/serverspec/salt_spec.rb
@@ -25,7 +25,7 @@ describe 'Salt Master' do
   end
 
   # Service check not supported in RedHat 5, however we still have the proccess check
-  unless os[:family] == 'RedHat' && os[:release] =~ /^5\./
+  unless os[:family] == 'redhat' && os[:release] =~ /^5\./
     describe service('salt-master') do
       it { should be_enabled }
       it { should be_running }
@@ -145,7 +145,7 @@ describe 'Salt Minion' do
   end
 
   # Service check not supported in RedHat 5, however we still have the proccess check
-  unless os[:family] == 'RedHat' && os[:release] =~ /^5\./
+  unless os[:family] == 'redhat' && os[:release] =~ /^5\./
     describe service('salt-minion') do
       it { should be_enabled }
       it { should be_running }

--- a/test/integration/version-pin/serverspec/salt_spec.rb
+++ b/test/integration/version-pin/serverspec/salt_spec.rb
@@ -4,7 +4,7 @@ set :backend, :exec
 
 describe 'Salt Key Exchange' do
   describe command('salt-key --list=pre') do
-    its(:stdout) { should match(/default-/) }
+    its(:stdout) { should match(/version-pin-/) }
   end
 end
 
@@ -30,6 +30,10 @@ describe 'Salt Master' do
 
   describe process('salt-master') do
     it { should be_running }
+  end
+
+  describe command('/usr/bin/salt-master --version') do
+    its(:stdout) { should match(/^salt-master 2016.3.0 \(Boron\)\n/) }
   end
 
   describe file('/etc/salt/master') do
@@ -125,7 +129,7 @@ describe 'Salt Minion' do
   describe file('/etc/salt/minion') do
     it { should be_file }
     its(:content) { should match(/^master: 127.0.0.1/) }
-    its(:content) { should match(/id: default-/) }
+    its(:content) { should match(/id: version-pin-/) }
     its(:content) { should match(/^  environment: _default/) }
     its(:content) { should match(/^    - salt_minion/) }
     its(:content) { should match(/^  quinoa: delicious/) }


### PR DESCRIPTION
- Allows different versions to be installed
- Adds support back for CentOS / RHEL 5.x
- Removes dependency on yum-epel repo
- Adds kitchen testing for the version attribute