### PR TITLE
split package repository setup to its own recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file is used to list changes made in each version of the Salt Cookbook
 
 ## Unreleased
 - **[PR #28](https://github.com/shortdudey123/chef-salt/pull/28)** - Add comments about AptRepository deprecation warning
+- **[PR #29](https://github.com/shortdudey123/chef-salt/pull/29)** - split package repository setup to its own recipe
 
 ## 2.0.0 (2016-09-13)
 - Remove CircleCI since TravisCI is already here

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
 
 default['salt']['version'] = nil # default: latest
+default['salt']['setup']['configure_repo'] = true
 
 default['salt']['role']['master'] = 'salt_master'
 default['salt']['role']['minion'] = 'salt_minion'

--- a/recipes/_setup.rb
+++ b/recipes/_setup.rb
@@ -21,39 +21,4 @@ ohai_plugin 'salt' do
   notifies :reload, 'ohai[salt]', :immediately
 end
 
-case node['platform_family']
-when 'debian'
-  # TODO: remove apt cookbook when dropping support for Chef < 12.9
-  # apt_repository resource was added to Chef 12.9 so this will throw deprecation warnings
-  # "WARN: Chef::Provider::AptRepository already exists!  Cannot create deprecation class for LWRP provider apt_repository from cookbook apt"
-  # "WARN: AptRepository already exists!  Deprecation class overwrites Custom resource apt_repository from cookbook apt"
-  include_recipe 'apt'
-
-  case node['platform']
-  when 'ubuntu'
-    apt_repository 'saltstack-salt' do
-      uri          'http://ppa.launchpad.net/saltstack/salt/ubuntu'
-      distribution node['lsb']['codename']
-      components   ['main']
-      keyserver    'keyserver.ubuntu.com'
-      key          '0E27C0A6'
-    end
-  when 'debian'
-    apt_repository 'saltstack-salt' do
-      uri          'http://debian.saltstack.com/debian'
-      distribution "#{node['lsb']['codename']}-saltstack"
-      components   ['main']
-      key          'http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key'
-    end
-  end
-when 'rhel'
-  minor_ver = node['salt']['version'] ? "archive/#{node['salt']['version'].split('-')[0]}" : 'latest'
-  gpg_keyname = node['platform_version'].to_i == 5 ? 'SALTSTACK-EL5-GPG-KEY' : 'SALTSTACK-GPG-KEY'
-
-  yum_repository 'saltstack-repo' do
-    description 'SaltStack repo for Red Hat Enterprise Linux $releasever'
-    baseurl "https://repo.saltstack.com/yum/redhat/$releasever/$basearch/#{minor_ver}"
-    gpgkey "https://repo.saltstack.com/yum/redhat/$releasever/$basearch/#{minor_ver}/#{gpg_keyname}.pub"
-    action :create
-  end
-end
+include_recipe 'salt::repo' if node['salt']['setup']['configure_repo']

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -1,0 +1,46 @@
+#
+# Cookbook Name:: chef-salt
+# Recipe:: repo
+#
+# Copyright (C) 2016, Grant Ridder
+# Copyright (C) 2014, Daryl Robbins
+#
+#
+#
+
+case node['platform_family']
+when 'debian'
+  # TODO: remove apt cookbook when dropping support for Chef < 12.9
+  # apt_repository resource was added to Chef 12.9 so this will throw deprecation warnings
+  # "WARN: Chef::Provider::AptRepository already exists!  Cannot create deprecation class for LWRP provider apt_repository from cookbook apt"
+  # "WARN: AptRepository already exists!  Deprecation class overwrites Custom resource apt_repository from cookbook apt"
+  include_recipe 'apt'
+
+  case node['platform']
+  when 'ubuntu'
+    apt_repository 'saltstack-salt' do
+      uri          'http://ppa.launchpad.net/saltstack/salt/ubuntu'
+      distribution node['lsb']['codename']
+      components   ['main']
+      keyserver    'keyserver.ubuntu.com'
+      key          '0E27C0A6'
+    end
+  when 'debian'
+    apt_repository 'saltstack-salt' do
+      uri          'http://debian.saltstack.com/debian'
+      distribution "#{node['lsb']['codename']}-saltstack"
+      components   ['main']
+      key          'http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key'
+    end
+  end
+when 'rhel'
+  minor_ver = node['salt']['version'] ? "archive/#{node['salt']['version'].split('-')[0]}" : 'latest'
+  gpg_keyname = node['platform_version'].to_i == 5 ? 'SALTSTACK-EL5-GPG-KEY' : 'SALTSTACK-GPG-KEY'
+
+  yum_repository 'saltstack-repo' do
+    description 'SaltStack repo for Red Hat Enterprise Linux $releasever'
+    baseurl "https://repo.saltstack.com/yum/redhat/$releasever/$basearch/#{minor_ver}"
+    gpgkey "https://repo.saltstack.com/yum/redhat/$releasever/$basearch/#{minor_ver}/#{gpg_keyname}.pub"
+    action :create
+  end
+end

--- a/spec/recipes/_setup_spec.rb
+++ b/spec/recipes/_setup_spec.rb
@@ -5,89 +5,29 @@ describe 'salt::_setup' do
     global_stubs_include_recipe
   end
 
-  context 'with default node attributes' do
-    let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-    it 'should include recipe salt::default' do
-      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('salt::default')
-      chef_run
-    end
-
-    it 'should include recipe ohai' do
-      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('ohai')
-      chef_run
-    end
-
-    it "should not create ohai['salt'] by default" do
-      expect(chef_run).to_not reload_ohai('salt')
-    end
-
-    it 'should create salt ohai_plugin' do
-      expect(chef_run).to create_ohai_plugin('salt').with(
-        source_file: 'salt_plugin.rb'
-      )
-      expect(chef_run.ohai_plugin('salt')).to notify('ohai[salt]').to(:reload).immediately
-    end
+  it 'should include recipe salt::default' do
+    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('salt::default')
+    chef_run
   end
 
-  context 'ubuntu with default node attributes' do
-    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
-
-    it 'should include recipe apt' do
-      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt')
-      chef_run
-    end
-
-    it 'creates saltstack-salt apt repository' do
-      expect(chef_run).to add_apt_repository('saltstack-salt').with(
-        uri: 'http://ppa.launchpad.net/saltstack/salt/ubuntu',
-        distribution: 'xenial',
-        components: %w(main),
-        keyserver: 'keyserver.ubuntu.com',
-        key: '0E27C0A6'
-      )
-    end
+  it 'should include recipe ohai' do
+    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('ohai')
+    chef_run
   end
 
-  context 'debian with default node attributes' do
-    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'debian', version: '8.5').converge(described_recipe) }
-
-    it 'should include recipe apt' do
-      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt')
-      chef_run
-    end
-
-    it 'creates saltstack-salt apt repository' do
-      expect(chef_run).to add_apt_repository('saltstack-salt').with(
-        uri: 'http://debian.saltstack.com/debian',
-        distribution: 'jessie-saltstack',
-        components: %w(main),
-        key: 'http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key'
-      )
-    end
+  it "should not create ohai['salt'] by default" do
+    expect(chef_run).to_not reload_ohai('salt')
   end
 
-  context 'centos 5 with default node attributes' do
-    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '5.11').converge(described_recipe) }
-
-    it 'creates saltstack-salt yum repository' do
-      expect(chef_run).to create_yum_repository('saltstack-repo').with(
-        description: 'SaltStack repo for Red Hat Enterprise Linux $releasever',
-        baseurl: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest',
-        gpgkey: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/SALTSTACK-EL5-GPG-KEY.pub'
-      )
-    end
+  it 'should create salt ohai_plugin' do
+    expect(chef_run).to create_ohai_plugin('salt').with(source_file: 'salt_plugin.rb')
+    expect(chef_run.ohai_plugin('salt')).to notify('ohai[salt]').to(:reload).immediately
   end
 
-  context 'centos > 5 with default node attributes' do
-    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7.2.1511').converge(described_recipe) }
-
-    it 'creates saltstack-salt yum repository' do
-      expect(chef_run).to create_yum_repository('saltstack-repo').with(
-        description: 'SaltStack repo for Red Hat Enterprise Linux $releasever',
-        baseurl: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest',
-        gpgkey: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/SALTSTACK-GPG-KEY.pub'
-      )
-    end
+  it 'should include recipe salt::repo' do
+    expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('salt::repo')
+    chef_run
   end
 end

--- a/spec/recipes/repo_spec.rb
+++ b/spec/recipes/repo_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe 'salt::repo' do
+  before do
+    global_stubs_include_recipe
+  end
+
+  context 'ubuntu with default node attributes' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+
+    it 'should include recipe apt' do
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt')
+      chef_run
+    end
+
+    it 'creates saltstack-salt apt repository' do
+      expect(chef_run).to add_apt_repository('saltstack-salt').with(
+        uri: 'http://ppa.launchpad.net/saltstack/salt/ubuntu',
+        distribution: 'xenial',
+        components: %w(main),
+        keyserver: 'keyserver.ubuntu.com',
+        key: '0E27C0A6'
+      )
+    end
+  end
+
+  context 'debian with default node attributes' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'debian', version: '8.5').converge(described_recipe) }
+
+    it 'should include recipe apt' do
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt')
+      chef_run
+    end
+
+    it 'creates saltstack-salt apt repository' do
+      expect(chef_run).to add_apt_repository('saltstack-salt').with(
+        uri: 'http://debian.saltstack.com/debian',
+        distribution: 'jessie-saltstack',
+        components: %w(main),
+        key: 'http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key'
+      )
+    end
+  end
+
+  context 'centos 5 with default node attributes' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '5.11').converge(described_recipe) }
+
+    it 'creates saltstack-salt yum repository' do
+      expect(chef_run).to create_yum_repository('saltstack-repo').with(
+        description: 'SaltStack repo for Red Hat Enterprise Linux $releasever',
+        baseurl: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest',
+        gpgkey: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/SALTSTACK-EL5-GPG-KEY.pub'
+      )
+    end
+  end
+
+  context 'centos > 5 with default node attributes' do
+    let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7.2.1511').converge(described_recipe) }
+
+    it 'creates saltstack-salt yum repository' do
+      expect(chef_run).to create_yum_repository('saltstack-repo').with(
+        description: 'SaltStack repo for Red Hat Enterprise Linux $releasever',
+        baseurl: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest',
+        gpgkey: 'https://repo.saltstack.com/yum/redhat/$releasever/$basearch/latest/SALTSTACK-GPG-KEY.pub'
+      )
+    end
+  end
+end


### PR DESCRIPTION
and add a `['salt']['setup']['configure_repo']` attribute to conditionally control its inclusion from the `_setup` recipe.

This allows those who have environments without access to external repositories to still use this cookbook.