### PR TITLE
Set default chefspec platform and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the Salt Cookbook
 ## Unreleased
 - **[PR #28](https://github.com/shortdudey123/chef-salt/pull/28)** - Add comments about AptRepository deprecation warning
 - **[PR #29](https://github.com/shortdudey123/chef-salt/pull/29)** - split package repository setup to its own recipe
+- **[PR #30](https://github.com/shortdudey123/chef-salt/pull/30)** - Set default chefspec platform and version
 
 ## 2.0.0 (2016-09-13)
 - Remove CircleCI since TravisCI is already here

--- a/spec/recipes/minion_spec.rb
+++ b/spec/recipes/minion_spec.rb
@@ -49,7 +49,7 @@ describe 'salt::minion' do
         variables: {
           chef_environment: '_default',
           config: {
-            'id' => 'chefspec.local',
+            'id' => 'fauxhai.local',
             'grains' => {},
             'ipv6' => false,
             'user' => 'root',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,8 +27,8 @@ module SaltCookbook
 end
 
 RSpec.configure do |config|
-  # config.platform = 'redhat'
-  # config.version = '7.2'
+  config.platform = 'redhat'
+  config.version = '7.2'
   config.include SaltCookbook::SpecHelper
 end
 


### PR DESCRIPTION
Cleans up ChefSpec warning
```
WARNING: you must specify a platform and platform_version to your ChefSpec Runner and/or Fauxhai constructor, in the future omitting these will become a hard error
```